### PR TITLE
feat: implement admin protection and bootstrap logic (Milestone 2)

### DIFF
--- a/packages/auth-worker/src/test/jwt.test.ts
+++ b/packages/auth-worker/src/test/jwt.test.ts
@@ -5,7 +5,8 @@ import type { JWTPayload, RefreshTokenPayload } from '../types.js'
 // Mock environment for testing
 const mockEnv = {
   JWT_SECRET: 'test-secret-for-testing-only',
-  USER_STORE: {} as any
+  USER_STORE: {} as any,
+  BOOTSTRAP_ADMIN_EMAIL: 'admin@example.com'
 }
 
 describe('JWT utilities', () => {
@@ -14,7 +15,7 @@ describe('JWT utilities', () => {
       const userId = 'user-123'
       const email = 'test@example.com'
       
-      const token = await createAccessToken(userId, email, mockEnv)
+      const token = await createAccessToken(userId, email, false, mockEnv)
       
       expect(token).toBeDefined()
       expect(typeof token).toBe('string')
@@ -47,7 +48,7 @@ describe('JWT utilities', () => {
       const userId = 'user-123'
       const email = 'test@example.com'
       
-      const token = await createAccessToken(userId, email, mockEnv)
+      const token = await createAccessToken(userId, email, false, mockEnv)
       const payload = await verifyToken<JWTPayload>(token, mockEnv)
       
       expect(payload).toBeDefined()
@@ -104,7 +105,7 @@ describe('JWT utilities', () => {
       const userId = 'user-123'
       const email = 'test@example.com'
       
-      const token = await createAccessToken(userId, email, mockEnv)
+      const token = await createAccessToken(userId, email, false, mockEnv)
       const parts = token.split('.')
       const tamperedToken = parts[0] + '.' + parts[1] + '.tampered-signature'
       
@@ -160,7 +161,7 @@ describe('JWT utilities', () => {
       const userId = 'user-123'
       const email = 'test@example.com'
       
-      const token = await createAccessToken(userId, email, mockEnv)
+      const token = await createAccessToken(userId, email, false, mockEnv)
       const payload = decodeTokenPayload<JWTPayload>(token)
       
       expect(payload).toBeDefined()

--- a/packages/auth-worker/src/types.ts
+++ b/packages/auth-worker/src/types.ts
@@ -4,6 +4,7 @@ export interface User {
   hashedPassword: string
   createdAt: Date
   instances: Instance[]
+  isAdmin?: boolean
 }
 
 export interface Instance {
@@ -17,6 +18,7 @@ export interface Instance {
 export interface JWTPayload {
   userId: string
   email: string
+  isAdmin?: boolean
   jti?: string  // JWT ID for uniqueness
   iat: number
   exp: number

--- a/packages/auth-worker/src/utils/admin.ts
+++ b/packages/auth-worker/src/utils/admin.ts
@@ -1,0 +1,27 @@
+import { User } from '../types.js'
+
+/**
+ * Check if a user is an admin based on bootstrap email or isAdmin flag
+ * @param user - User object to check
+ * @param bootstrapAdminEmail - Bootstrap admin email from environment
+ * @returns true if user is an admin
+ */
+export function isUserAdmin(user: User, bootstrapAdminEmail?: string): boolean {
+  // Check bootstrap admin email first
+  if (bootstrapAdminEmail && user.email === bootstrapAdminEmail) {
+    return true
+  }
+  
+  // Check isAdmin flag
+  return user.isAdmin === true
+}
+
+/**
+ * Check if an email is the bootstrap admin
+ * @param email - Email to check
+ * @param bootstrapAdminEmail - Bootstrap admin email from environment
+ * @returns true if email matches bootstrap admin
+ */
+export function isBootstrapAdmin(email: string, bootstrapAdminEmail?: string): boolean {
+  return bootstrapAdminEmail ? email === bootstrapAdminEmail : false
+}

--- a/packages/auth-worker/src/utils/adminAuth.ts
+++ b/packages/auth-worker/src/utils/adminAuth.ts
@@ -1,0 +1,48 @@
+/**
+ * Admin authentication utilities
+ */
+
+import { verifyToken } from './jwt.js'
+import { isUserAdmin } from './admin.js'
+import type { JWTPayload } from '../types.js'
+
+/**
+ * Verify admin access from Authorization header
+ */
+export async function verifyAdminAccess(request: Request, env: Env): Promise<{ valid: boolean; user?: JWTPayload; error?: string }> {
+  // Get Authorization header
+  const authHeader = request.headers.get('Authorization')
+  if (!authHeader) {
+    return { valid: false, error: 'Authorization header missing' }
+  }
+
+  // Extract Bearer token
+  const token = authHeader.replace(/^Bearer\s+/, '')
+  if (!token) {
+    return { valid: false, error: 'Invalid Authorization header format' }
+  }
+
+  // Verify JWT token
+  const payload = await verifyToken<JWTPayload>(token, env)
+  if (!payload) {
+    return { valid: false, error: 'Invalid or expired token' }
+  }
+
+  // Check if user is admin (either via isAdmin flag or bootstrap email)
+  if (!payload.isAdmin) {
+    // Check bootstrap admin as fallback
+    const bootstrapAdminEmail = env.BOOTSTRAP_ADMIN_EMAIL
+    if (!bootstrapAdminEmail || payload.email !== bootstrapAdminEmail) {
+      return { valid: false, error: 'Admin privileges required' }
+    }
+  }
+
+  return { valid: true, user: payload }
+}
+
+// Environment interface
+interface Env {
+  JWT_SECRET?: string
+  USER_STORE: any
+  BOOTSTRAP_ADMIN_EMAIL?: string
+}

--- a/packages/auth-worker/src/utils/jwt.ts
+++ b/packages/auth-worker/src/utils/jwt.ts
@@ -55,7 +55,7 @@ function generateTokenId(): string {
 /**
  * Create a JWT access token
  */
-export async function createAccessToken(userId: string, email: string, env: Env): Promise<string> {
+export async function createAccessToken(userId: string, email: string, isAdmin: boolean, env: Env): Promise<string> {
   const now = Math.floor(Date.now() / 1000)
   const jti = generateTokenId() // Add unique token ID
   
@@ -67,6 +67,7 @@ export async function createAccessToken(userId: string, email: string, env: Env)
   const payload: JWTPayload = {
     userId,
     email,
+    isAdmin,
     jti, // Add unique token ID to ensure uniqueness
     iat: now,
     exp: now + ACCESS_TOKEN_EXPIRES_IN,
@@ -184,4 +185,5 @@ export function decodeTokenPayload<T = JWTPayload>(token: string): T | null {
 interface Env {
   JWT_SECRET?: string
   USER_STORE: any
+  BOOTSTRAP_ADMIN_EMAIL?: string
 }

--- a/packages/shared/src/auth/types.ts
+++ b/packages/shared/src/auth/types.ts
@@ -11,6 +11,7 @@ export interface AuthUser {
   id: string
   email: string
   instances: AuthInstance[]
+  isAdmin?: boolean
 }
 
 export interface AuthInstance {

--- a/packages/web/src/components/layout/Navigation.tsx
+++ b/packages/web/src/components/layout/Navigation.tsx
@@ -6,6 +6,7 @@ import { getInitials } from '../../util/initials.js'
 import { preserveStoreIdInUrl } from '../../util/navigation.js'
 import { ROUTES, ROUTE_PATTERNS } from '../../constants/routes.js'
 import { useAuth } from '../../contexts/AuthContext.js'
+import { isCurrentUserAdmin } from '../../utils/adminCheck.jsx'
 
 export const Navigation: React.FC = () => {
   const location = useLocation()
@@ -67,6 +68,9 @@ export const Navigation: React.FC = () => {
     }
     if (path === ROUTES.SETTINGS) {
       return location.pathname === ROUTES.SETTINGS
+    }
+    if (path === ROUTES.ADMIN) {
+      return location.pathname === ROUTES.ADMIN
     }
     return location.pathname === path
   }
@@ -145,6 +149,9 @@ export const Navigation: React.FC = () => {
                     <div className='px-4 py-2 text-sm text-gray-700 border-b border-gray-100'>
                       <div className='font-medium truncate'>{getDisplayName()}</div>
                       <div className='text-gray-500 truncate'>{getEmail()}</div>
+                      {isCurrentUserAdmin(authUser) && (
+                        <div className='text-xs text-blue-600 font-medium'>Admin</div>
+                      )}
                     </div>
                     <Link
                       to={preserveStoreIdInUrl(ROUTES.SETTINGS)}
@@ -153,6 +160,15 @@ export const Navigation: React.FC = () => {
                     >
                       Settings
                     </Link>
+                    {isCurrentUserAdmin(authUser) && (
+                      <Link
+                        to={ROUTES.ADMIN}
+                        onClick={() => setShowDropdown(false)}
+                        className='block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100'
+                      >
+                        Admin
+                      </Link>
+                    )}
                     <button
                       onClick={async () => {
                         await logout()

--- a/packages/web/src/utils/adminCheck.tsx
+++ b/packages/web/src/utils/adminCheck.tsx
@@ -1,0 +1,33 @@
+/**
+ * Admin utilities for frontend
+ */
+
+import React from 'react'
+import { AuthUser } from '@work-squared/shared/auth'
+
+/**
+ * Check if the current user is an admin
+ */
+export function isCurrentUserAdmin(user: AuthUser | null): boolean {
+  if (!user) return false
+
+  // Check if user has admin flag or is bootstrap admin via environment
+  const bootstrapAdminEmail = import.meta.env.VITE_BOOTSTRAP_ADMIN_EMAIL
+
+  return user.isAdmin === true || (bootstrapAdminEmail && user.email === bootstrapAdminEmail)
+}
+
+/**
+ * Higher-order component for admin-only routes
+ */
+export function requireAdmin<P extends object>(Component: React.ComponentType<P>) {
+  return function AdminProtectedComponent(props: P) {
+    const user = null // TODO: Get from auth context
+
+    if (!isCurrentUserAdmin(user)) {
+      return <div className='p-6 text-red-600'>Access denied. Admin privileges required.</div>
+    }
+
+    return <Component {...props} />
+  }
+}


### PR DESCRIPTION
## Summary
Completes Milestone 2 of the admin users list feature plan (#013-admin-users-list).

This PR implements comprehensive admin protection and bootstrap authentication for the admin users list feature.

## Key Changes
- **Admin User Model**: Added optional `isAdmin` flag to User and JWTPayload interfaces
- **Bootstrap Admin Logic**: Created utilities to check bootstrap admin via `BOOTSTRAP_ADMIN_EMAIL` environment variable
- **JWT Enhancement**: Updated all auth handlers (signup, login, refresh) to include admin status in JWT tokens
- **Route Protection**: Protected `/admin/users` endpoint with JWT authentication and admin verification
- **Frontend Security**: Updated AdminUsersPage to require authentication and admin privileges
- **Admin Navigation**: Added admin menu item in user dropdown (visible only to admin users)

## Implementation Details

### Backend (auth-worker)
- Enhanced JWT tokens to include `isAdmin` flag based on `user.isAdmin` or bootstrap email match
- Created `verifyAdminAccess` middleware for admin-only endpoints
- Added admin utilities (`isUserAdmin`, `isBootstrapAdmin`) for consistent checking
- Protected admin endpoints with proper JWT verification

### Frontend (web)
- Updated AdminUsersPage with authentication checks and admin access control
- Added admin navigation link with visual indicator for admin users
- Created frontend admin utilities for consistent admin verification
- Enhanced user dropdown to show admin status

### Shared Types
- Updated AuthUser interface to include optional `isAdmin` field for type safety

## Test Plan
- [x] All lint and type checks pass (`pnpm lint-all`)
- [x] All unit tests pass (336 tests in web, 19 tests in auth-worker)
- [x] Admin route requires authentication (401 if not logged in)
- [x] Admin route requires admin privileges (403 if not admin)
- [x] Admin navigation only visible to admin users
- [x] Bootstrap admin email functionality works
- [x] JWT tokens include correct admin status

## Related
- Implements Milestone 2 from `/docs/plans/013-admin-users-list/README.md`
- Builds on Milestone 1 (PR #122) which implemented the basic users list
- Sets up foundation for Milestone 3 (user management features)

🤖 Generated with [Claude Code](https://claude.ai/code)