### PR TITLE
feat: Implement Phase 3 recurring tasks - manual execution and history

### DIFF
--- a/packages/shared/src/livestore/events.ts
+++ b/packages/shared/src/livestore/events.ts
@@ -347,6 +347,44 @@ export const recurringTaskDisabled = Events.synced({
   }),
 })
 
+export const recurringTaskExecute = Events.synced({
+  name: 'v1.RecurringTaskExecute',
+  schema: Schema.Struct({
+    taskId: Schema.String,
+    triggerType: Schema.Union(Schema.Literal('manual'), Schema.Literal('automatic')),
+    triggeredAt: Schema.Date,
+  }),
+})
+
+export const taskExecutionStarted = Events.synced({
+  name: 'v1.TaskExecutionStarted',
+  schema: Schema.Struct({
+    id: Schema.String,
+    recurringTaskId: Schema.String,
+    triggerType: Schema.Union(Schema.Literal('manual'), Schema.Literal('automatic')),
+    startedAt: Schema.Date,
+  }),
+})
+
+export const taskExecutionCompleted = Events.synced({
+  name: 'v1.TaskExecutionCompleted',
+  schema: Schema.Struct({
+    id: Schema.String,
+    completedAt: Schema.Date,
+    output: Schema.Union(Schema.String, Schema.Undefined),
+    createdTaskIds: Schema.Union(Schema.Array(Schema.String), Schema.Undefined),
+  }),
+})
+
+export const taskExecutionFailed = Events.synced({
+  name: 'v1.TaskExecutionFailed',
+  schema: Schema.Struct({
+    id: Schema.String,
+    failedAt: Schema.Date,
+    error: Schema.String,
+  }),
+})
+
 export const settingUpdated = Events.synced({
   name: 'v1.SettingUpdated',
   schema: Schema.Struct({

--- a/packages/shared/src/livestore/queries.ts
+++ b/packages/shared/src/livestore/queries.ts
@@ -282,3 +282,24 @@ export const getRecurringTaskById$ = (id: string) =>
   queryDb(tables.recurringTasks.select().where({ id }), {
     label: `getRecurringTaskById:${id}`,
   })
+
+// Task execution queries
+export const getTaskExecutions$ = (taskId: string) =>
+  queryDb(
+    tables.taskExecutions
+      .select()
+      .where({ recurringTaskId: taskId })
+      .orderBy([{ col: 'startedAt', direction: 'desc' }])
+      .limit(5),
+    { label: `getTaskExecutions:${taskId}` }
+  )
+
+export const getLatestExecution$ = (taskId: string) =>
+  queryDb(
+    tables.taskExecutions
+      .select()
+      .where({ recurringTaskId: taskId })
+      .orderBy([{ col: 'startedAt', direction: 'desc' }])
+      .limit(1),
+    { label: `getLatestExecution:${taskId}` }
+  )

--- a/packages/web/src/Root.tsx
+++ b/packages/web/src/Root.tsx
@@ -28,6 +28,7 @@ import { ErrorBoundary } from './components/ui/ErrorBoundary/ErrorBoundary.js'
 import { UserInitializer } from './components/utils/UserInitializer/UserInitializer.js'
 import { AuthUserSync } from './components/utils/AuthUserSync/AuthUserSync.js'
 import { SettingsInitializer } from './components/utils/SettingsInitializer/SettingsInitializer.js'
+import { TaskScheduler } from './components/recurring-tasks/TaskScheduler.js'
 import { schema } from '@work-squared/shared/schema'
 import { ROUTES } from './constants/routes.js'
 
@@ -126,6 +127,7 @@ const ProtectedApp: React.FC = () => (
         <UserInitializer>
           <AuthUserSync>
             <SettingsInitializer>
+              <TaskScheduler />
               <ErrorBoundary>
                 <Routes>
                   <Route

--- a/packages/web/src/components/recurring-tasks/ExecutionHistory.tsx
+++ b/packages/web/src/components/recurring-tasks/ExecutionHistory.tsx
@@ -1,0 +1,109 @@
+import React from 'react'
+import { formatRelativeTime } from '@work-squared/shared'
+import type { TaskExecution } from '@work-squared/shared/schema'
+
+interface ExecutionHistoryProps {
+  executions: TaskExecution[]
+}
+
+export const ExecutionHistory: React.FC<ExecutionHistoryProps> = ({ executions }) => {
+  if (executions.length === 0) {
+    return null
+  }
+
+  return (
+    <div className='space-y-1'>
+      <h5 className='text-xs font-medium text-gray-500 mb-1'>Recent Executions</h5>
+      {executions.map(execution => {
+        const isRunning = execution.status === 'running'
+        const isFailed = execution.status === 'failed'
+        const isCompleted = execution.status === 'completed'
+
+        return (
+          <div key={execution.id} className='flex items-center gap-2 text-xs text-gray-600'>
+            {/* Status Icon */}
+            <div className='flex-shrink-0'>
+              {isRunning && (
+                <svg className='w-3 h-3 text-blue-500 animate-spin' fill='none' viewBox='0 0 24 24'>
+                  <circle
+                    className='opacity-25'
+                    cx='12'
+                    cy='12'
+                    r='10'
+                    stroke='currentColor'
+                    strokeWidth='4'
+                  />
+                  <path
+                    className='opacity-75'
+                    fill='currentColor'
+                    d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
+                  />
+                </svg>
+              )}
+              {isCompleted && (
+                <svg className='w-3 h-3 text-green-500' fill='currentColor' viewBox='0 0 20 20'>
+                  <path
+                    fillRule='evenodd'
+                    d='M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z'
+                    clipRule='evenodd'
+                  />
+                </svg>
+              )}
+              {isFailed && (
+                <svg className='w-3 h-3 text-red-500' fill='currentColor' viewBox='0 0 20 20'>
+                  <path
+                    fillRule='evenodd'
+                    d='M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z'
+                    clipRule='evenodd'
+                  />
+                </svg>
+              )}
+            </div>
+
+            {/* Execution Info */}
+            <div className='flex-1 flex items-center gap-2'>
+              <span
+                className={`font-medium ${
+                  isRunning ? 'text-blue-600' : isFailed ? 'text-red-600' : 'text-gray-600'
+                }`}
+              >
+                {isRunning ? 'Running' : isCompleted ? 'Completed' : 'Failed'}
+              </span>
+
+              <span className='text-gray-400'>
+                {execution.triggerType === 'automatic' ? 'Auto' : 'Manual'}
+              </span>
+
+              <span className='text-gray-500'>
+                {formatRelativeTime(execution.startedAt.getTime())}
+              </span>
+
+              {execution.completedAt && !isRunning && (
+                <span className='text-gray-400'>
+                  (
+                  {Math.round(
+                    (execution.completedAt.getTime() - execution.startedAt.getTime()) / 1000
+                  )}
+                  s)
+                </span>
+              )}
+
+              {execution.output && isCompleted && (
+                <span className='text-gray-500 truncate flex-1' title={execution.output}>
+                  {JSON.parse(execution.output).error || execution.output.substring(0, 50)}
+                </span>
+              )}
+
+              {execution.createdTaskIds && (
+                <span className='text-blue-600'>
+                  {JSON.parse(execution.createdTaskIds).length} task
+                  {JSON.parse(execution.createdTaskIds).length !== 1 ? 's' : ''} created
+                </span>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/web/src/components/recurring-tasks/RecurringTaskCard.test.tsx
+++ b/packages/web/src/components/recurring-tasks/RecurringTaskCard.test.tsx
@@ -41,6 +41,7 @@ describe('RecurringTaskCard', () => {
   const mockOnEdit = vi.fn()
   const mockOnDelete = vi.fn()
   const mockOnToggleEnabled = vi.fn()
+  const mockOnExecute = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -53,6 +54,7 @@ describe('RecurringTaskCard', () => {
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onToggleEnabled={mockOnToggleEnabled}
+        onExecute={mockOnExecute}
       />
     )
 
@@ -69,6 +71,7 @@ describe('RecurringTaskCard', () => {
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onToggleEnabled={mockOnToggleEnabled}
+        onExecute={mockOnExecute}
       />
     )
 
@@ -84,6 +87,7 @@ describe('RecurringTaskCard', () => {
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onToggleEnabled={mockOnToggleEnabled}
+        onExecute={mockOnExecute}
       />
     )
 
@@ -106,6 +110,7 @@ describe('RecurringTaskCard', () => {
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onToggleEnabled={mockOnToggleEnabled}
+        onExecute={mockOnExecute}
       />
     )
 
@@ -128,6 +133,7 @@ describe('RecurringTaskCard', () => {
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onToggleEnabled={mockOnToggleEnabled}
+        onExecute={mockOnExecute}
       />
     )
 
@@ -153,6 +159,7 @@ describe('RecurringTaskCard', () => {
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onToggleEnabled={mockOnToggleEnabled}
+        onExecute={mockOnExecute}
       />
     )
 
@@ -183,6 +190,7 @@ describe('RecurringTaskCard', () => {
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onToggleEnabled={mockOnToggleEnabled}
+        onExecute={mockOnExecute}
       />
     )
 
@@ -207,6 +215,7 @@ describe('RecurringTaskCard', () => {
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onToggleEnabled={mockOnToggleEnabled}
+        onExecute={mockOnExecute}
       />
     )
 
@@ -232,6 +241,7 @@ describe('RecurringTaskCard', () => {
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onToggleEnabled={mockOnToggleEnabled}
+        onExecute={mockOnExecute}
       />
     )
 
@@ -250,6 +260,7 @@ describe('RecurringTaskCard', () => {
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onToggleEnabled={mockOnToggleEnabled}
+        onExecute={mockOnExecute}
       />
     )
 

--- a/packages/web/src/components/recurring-tasks/RecurringTasksList.tsx
+++ b/packages/web/src/components/recurring-tasks/RecurringTasksList.tsx
@@ -16,7 +16,7 @@ export const RecurringTasksList: React.FC<RecurringTasksListProps> = ({
   projectId,
 }) => {
   const allRecurringTasks = useQuery(getRecurringTasks$) ?? []
-  const { deleteRecurringTask, toggleRecurringTask } = useRecurringTasks()
+  const { deleteRecurringTask, toggleRecurringTask, executeRecurringTask } = useRecurringTasks()
   const [editingTask, setEditingTask] = useState<RecurringTask | null>(null)
 
   // Filter tasks by project if projectId is provided
@@ -39,6 +39,10 @@ export const RecurringTasksList: React.FC<RecurringTasksListProps> = ({
 
   const handleToggleEnabled = async (taskId: string, enabled: boolean) => {
     await toggleRecurringTask(taskId, enabled)
+  }
+
+  const handleExecute = async (taskId: string) => {
+    await executeRecurringTask(taskId)
   }
 
   if (recurringTasks.length === 0) {
@@ -83,6 +87,7 @@ export const RecurringTasksList: React.FC<RecurringTasksListProps> = ({
             onEdit={handleEdit}
             onDelete={handleDelete}
             onToggleEnabled={handleToggleEnabled}
+            onExecute={handleExecute}
           />
         ))}
         <div className='pt-2'>

--- a/packages/web/src/components/recurring-tasks/TaskScheduler.tsx
+++ b/packages/web/src/components/recurring-tasks/TaskScheduler.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react'
+import { useQuery } from '@livestore/react'
+import { getRecurringTasks$ } from '@work-squared/shared/queries'
+import { useRecurringTasks } from '../../hooks/useRecurringTasks.js'
+
+/**
+ * TaskScheduler component that checks for due recurring tasks and executes them automatically.
+ * This is a frontend implementation for Phase 3, simulating automatic execution.
+ */
+export const TaskScheduler: React.FC = () => {
+  const recurringTasks = useQuery(getRecurringTasks$) ?? []
+  const { executeRecurringTask } = useRecurringTasks()
+  const executingTasks = useRef<Set<string>>(new Set())
+  const checkIntervalRef = useRef<NodeJS.Timeout | null>(null)
+
+  useEffect(() => {
+    const checkAndExecuteTasks = async () => {
+      const now = Date.now()
+
+      // Find enabled tasks that are due for execution
+      const dueTasks = recurringTasks.filter(task => {
+        if (!task.enabled) return false
+        if (!task.nextExecutionAt) return false
+        if (executingTasks.current.has(task.id)) return false // Already executing
+
+        // Check if task is due (nextExecutionAt is in the past)
+        return task.nextExecutionAt.getTime() <= now
+      })
+
+      // Execute due tasks
+      for (const task of dueTasks) {
+        console.log(`Executing scheduled task: ${task.name}`)
+        executingTasks.current.add(task.id)
+
+        try {
+          await executeRecurringTask(task.id, 'automatic')
+        } catch (error) {
+          console.error(`Failed to execute task ${task.name}:`, error)
+        } finally {
+          // Remove from executing set after a delay to prevent rapid re-execution
+          setTimeout(() => {
+            executingTasks.current.delete(task.id)
+          }, 5000)
+        }
+      }
+    }
+
+    // Check every 30 seconds for due tasks
+    checkAndExecuteTasks() // Check immediately
+    checkIntervalRef.current = setInterval(checkAndExecuteTasks, 30000)
+
+    return () => {
+      if (checkIntervalRef.current) {
+        clearInterval(checkIntervalRef.current)
+      }
+    }
+  }, [recurringTasks, executeRecurringTask])
+
+  // This component doesn't render anything
+  return null
+}


### PR DESCRIPTION
## Summary
- Implements Phase 3 of recurring tasks feature as specified in docs/plans/014-email-drafting-via-mcp/recurring-tasks-implementation-todo.md
- Adds manual task execution capability with real-time status feedback
- Implements execution history tracking with inline display

## Changes
### Backend (LiveStore)
- Added `task_executions` table to track all task executions
- Added execution events: `recurringTaskExecute`, `taskExecutionStarted`, `taskExecutionCompleted`, `taskExecutionFailed`
- Added materializers to update execution records and track lastExecutedAt
- Added queries to fetch execution history (last 5 executions per task)

### Frontend
- Added "Run Now" button to RecurringTaskCard with loading/running states
- Created ExecutionHistory component showing inline execution history
- Updated useRecurringTasks hook with executeRecurringTask operation
- Mock execution handler (2-second delay) for testing
- Added automatic scheduling check via TaskScheduler component (checks every 30 seconds)
- Updates nextExecutionAt after successful execution

## Test plan
- [x] All existing tests pass
- [x] lint-all passes with no errors
- [x] Manual testing:
  - [ ] Create a recurring task
  - [ ] Click "Run Now" button to manually execute
  - [ ] See task enter running state with spinner
  - [ ] After 2 seconds, see execution complete
  - [ ] View execution history showing Manual/Completed status
  - [ ] Create task with 1-minute interval for testing automatic execution
  - [ ] Wait for automatic execution at scheduled time
  - [ ] See execution history shows both Manual and Auto executions

## Next Steps
Phase 4 will move execution to server-side once multi-store support is complete.

🤖 Generated with [Claude Code](https://claude.ai/code)