### PR TITLE
fix: resolve server test failures and include server tests in root test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:server": "pnpm --filter @work-squared/server dev",
     "dev:auth": "pnpm --filter @work-squared/auth-worker dev",
     "build": "pnpm -r build",
-    "test": "pnpm --filter @work-squared/web test && pnpm --filter @work-squared/auth-worker test",
+    "test": "pnpm --filter @work-squared/web test && pnpm --filter @work-squared/auth-worker test && pnpm --filter @work-squared/server test",
     "test:watch": "pnpm --filter @work-squared/web test:watch",
     "test:e2e": "pnpm --filter @work-squared/web test:e2e",
     "test:e2e:ui": "pnpm --filter @work-squared/web test:e2e:ui",

--- a/packages/server/src/services/event-processor-infinite-loop.test.ts
+++ b/packages/server/src/services/event-processor-infinite-loop.test.ts
@@ -55,11 +55,14 @@ describe('EventProcessor - Infinite Loop Prevention', () => {
     const chatMessagesCallback = subscriptionCallbacks.get('chatMessages')
     expect(chatMessagesCallback).toBeDefined()
 
-    // Simulate initial message arrival
+    // Simulate initial subscription with empty array (initial sync)
+    chatMessagesCallback!([])
+
+    // Simulate new message arrival
     chatMessagesCallback!(chatMessages)
 
-    // Wait for async setTimeout to complete
-    await new Promise(resolve => setTimeout(resolve, 10))
+    // Wait for async setImmediate to complete
+    await new Promise(resolve => setImmediate(resolve))
 
     // Verify handleUserMessage was called once
     expect(mockStore.commit).toHaveBeenCalledTimes(1)
@@ -107,6 +110,9 @@ describe('EventProcessor - Infinite Loop Prevention', () => {
     const chatMessagesCallback = subscriptionCallbacks.get('chatMessages')
     expect(chatMessagesCallback).toBeDefined()
 
+    // Simulate initial subscription with empty array
+    chatMessagesCallback!([])
+
     // First message
     const firstMessage = {
       id: 'msg-1',
@@ -118,8 +124,8 @@ describe('EventProcessor - Infinite Loop Prevention', () => {
 
     chatMessagesCallback!([firstMessage])
 
-    // Wait for async setTimeout to complete
-    await new Promise(resolve => setTimeout(resolve, 10))
+    // Wait for async setImmediate to complete
+    await new Promise(resolve => setImmediate(resolve))
 
     expect(mockStore.commit).toHaveBeenCalledTimes(1)
     expect(mockStore.commit).toHaveBeenCalledWith(
@@ -144,8 +150,8 @@ describe('EventProcessor - Infinite Loop Prevention', () => {
     // LiveStore returns full dataset including both messages
     chatMessagesCallback!([firstMessage, secondMessage])
 
-    // Wait for async setTimeout to complete
-    await new Promise(resolve => setTimeout(resolve, 10))
+    // Wait for async setImmediate to complete
+    await new Promise(resolve => setImmediate(resolve))
 
     // Should only process the new message, not the first one again
     expect(mockStore.commit).toHaveBeenCalledTimes(1)
@@ -165,6 +171,9 @@ describe('EventProcessor - Infinite Loop Prevention', () => {
 
     const chatMessagesCallback = subscriptionCallbacks.get('chatMessages')
     expect(chatMessagesCallback).toBeDefined()
+
+    // Simulate initial subscription with empty array
+    chatMessagesCallback!([])
 
     // Assistant message (should be ignored)
     const assistantMessage = {


### PR DESCRIPTION
## Summary
- Fixed failing tests in `packages/server/src/services/event-processor-infinite-loop.test.ts`
- Added `@work-squared/server` package to root test command so server tests run with `pnpm test`
- Implemented test mode in EventProcessor for handling messages without LLM configuration

## Test plan
- [x] All server tests now pass including the previously failing infinite loop prevention tests
- [x] Server tests are included when running `pnpm test` from project root
- [x] Code passes lint-all and typecheck
- [x] Test mode provides echo responses for messages with `server:` prefix when LLM is not configured

## Changes Made
1. **Root package.json**: Added `&& pnpm --filter @work-squared/server test` to test script
2. **EventProcessor**: Added test mode logic to handle messages without LLM provider
3. **Test fixes**: Updated test to properly simulate LiveStore subscription behavior with initial empty array call
4. **Async handling**: Changed from `setTimeout` to `setImmediate` for better async test timing

🤖 Generated with [Claude Code](https://claude.ai/code)