### PR TITLE
Fix Cursor review feedback on CHORUS_TAG implementation

### DIFF
--- a/packages/server/src/services/agentic-loop/tool-formatters/chorus-formatter.ts
+++ b/packages/server/src/services/agentic-loop/tool-formatters/chorus-formatter.ts
@@ -13,32 +13,28 @@ export class ChorusFormatter {
   /**
    * Wraps a document ID in a CHORUS_TAG for navigation to document editor
    */
-  static document(documentId: string, displayText?: string): string {
-    const text = displayText || documentId
+  static document(documentId: string): string {
     return `<CHORUS_TAG>document:${documentId}</CHORUS_TAG>`
   }
 
   /**
    * Wraps a project ID in a CHORUS_TAG for navigation to project page
    */
-  static project(projectId: string, displayText?: string): string {
-    const text = displayText || projectId
+  static project(projectId: string): string {
     return `<CHORUS_TAG>project:${projectId}</CHORUS_TAG>`
   }
 
   /**
    * Wraps a task ID in a CHORUS_TAG for navigation to task details
    */
-  static task(taskId: string, displayText?: string): string {
-    const text = displayText || taskId
+  static task(taskId: string): string {
     return `<CHORUS_TAG>task:${taskId}</CHORUS_TAG>`
   }
 
   /**
    * Wraps a file path in a CHORUS_TAG for file system navigation
    */
-  static file(filePath: string, displayText?: string): string {
-    const text = displayText || filePath
+  static file(filePath: string): string {
     return `<CHORUS_TAG>${filePath}</CHORUS_TAG>`
   }
 

--- a/packages/server/src/services/agentic-loop/tool-formatters/document-formatter.ts
+++ b/packages/server/src/services/agentic-loop/tool-formatters/document-formatter.ts
@@ -82,7 +82,7 @@ export class DocumentToolFormatter implements ToolResultFormatter {
       result.documents
         ?.map(
           (d: any) =>
-            `${d.title} (ID: ${d.id}) - Created: ${new Date(d.createdAt).toLocaleDateString()}`
+            `${d.title} (ID: ${ChorusFormatter.document(d.id)}) - Created: ${new Date(d.createdAt).toLocaleDateString()}`
         )
         .join('\n• ') || 'No documents found in project'
     return `Project documents:\n• ${documentList}`
@@ -91,7 +91,9 @@ export class DocumentToolFormatter implements ToolResultFormatter {
   private formatSearchProjectDocuments(result: any): string {
     const searchResults =
       result.results
-        ?.map((r: any) => `${r.title} (ID: ${r.id})\n  Snippet: ${r.snippet}`)
+        ?.map(
+          (r: any) => `${r.title} (ID: ${ChorusFormatter.document(r.id)})\n  Snippet: ${r.snippet}`
+        )
         .join('\n\n• ') || 'No matching documents found in project'
     return `Project search results:\n• ${searchResults}`
   }

--- a/packages/server/src/services/agentic-loop/tool-formatters/document-formatter.ts
+++ b/packages/server/src/services/agentic-loop/tool-formatters/document-formatter.ts
@@ -133,6 +133,9 @@ export class DocumentToolFormatter implements ToolResultFormatter {
   }
 
   private formatRemoveDocumentFromProject(result: any): string {
-    return `Document successfully removed from project:\n• Document ID: ${result.association?.documentId}\n• Project ID: ${result.association?.projectId}`
+    if (!result.association?.documentId || !result.association?.projectId) {
+      return 'Document remove from project failed: Missing document or project ID'
+    }
+    return `Document successfully removed from project:\n• Document ID: ${ChorusFormatter.document(result.association.documentId)}\n• Project ID: ${ChorusFormatter.project(result.association.projectId)}`
   }
 }

--- a/packages/server/src/services/agentic-loop/tool-formatters/document-formatter.ts
+++ b/packages/server/src/services/agentic-loop/tool-formatters/document-formatter.ts
@@ -105,7 +105,10 @@ export class DocumentToolFormatter implements ToolResultFormatter {
   }
 
   private formatUpdateDocument(result: any): string {
-    let message = `Document updated successfully:\n• Document ID: ${ChorusFormatter.document(result.document?.id)}`
+    if (!result.document?.id) {
+      return 'Document update failed: Document ID not found'
+    }
+    let message = `Document updated successfully:\n• Document ID: ${ChorusFormatter.document(result.document.id)}`
     if (result.document?.title) {
       message += `\n• New title: ${result.document.title}`
     }
@@ -116,11 +119,17 @@ export class DocumentToolFormatter implements ToolResultFormatter {
   }
 
   private formatArchiveDocument(result: any): string {
-    return `Document archived successfully:\n• Document ID: ${result.document?.id}`
+    if (!result.document?.id) {
+      return 'Document archive failed: Document ID not found'
+    }
+    return `Document archived successfully:\n• Document ID: ${ChorusFormatter.document(result.document.id)}`
   }
 
   private formatAddDocumentToProject(result: any): string {
-    return `Document successfully added to project:\n• Document ID: ${result.association?.documentId}\n• Project ID: ${result.association?.projectId}`
+    if (!result.association?.documentId || !result.association?.projectId) {
+      return 'Document add to project failed: Missing document or project ID'
+    }
+    return `Document successfully added to project:\n• Document ID: ${ChorusFormatter.document(result.association.documentId)}\n• Project ID: ${ChorusFormatter.project(result.association.projectId)}`
   }
 
   private formatRemoveDocumentFromProject(result: any): string {

--- a/packages/server/src/services/agentic-loop/tool-formatters/project-formatter.ts
+++ b/packages/server/src/services/agentic-loop/tool-formatters/project-formatter.ts
@@ -51,7 +51,7 @@ export class ProjectToolFormatter implements ToolResultFormatter {
       return 'Project not found'
     }
     const p = result.project
-    return `Project details:\n• ID: ${p.id}\n• Name: ${p.name}\n• Description: ${
+    return `Project details:\n• ID: ${ChorusFormatter.project(p.id)}\n• Name: ${p.name}\n• Description: ${
       p.description || 'none'
     }\n• Document count: ${p.documentCount}\n• Task count: ${p.taskCount}`
   }

--- a/packages/server/src/services/agentic-loop/tool-formatters/task-formatter.ts
+++ b/packages/server/src/services/agentic-loop/tool-formatters/task-formatter.ts
@@ -52,7 +52,10 @@ export class TaskToolFormatter implements ToolResultFormatter {
   }
 
   private formatUpdateTask(result: any): string {
-    let message = `Task updated successfully:\n• Task ID: ${ChorusFormatter.task(result.task?.id)}`
+    if (!result.task?.id) {
+      return 'Task update failed: Task ID not found'
+    }
+    let message = `Task updated successfully:\n• Task ID: ${ChorusFormatter.task(result.task.id)}`
     if (result.task?.title) {
       message += `\n• New title: ${result.task.title}`
     }
@@ -66,22 +69,34 @@ export class TaskToolFormatter implements ToolResultFormatter {
   }
 
   private formatMoveTask(result: any): string {
-    return `Task moved successfully:\n• Task ID: ${ChorusFormatter.task(result.task?.id)}\n• New column ID: ${result.task?.columnId}\n• Position: ${result.task?.position}`
+    if (!result.task?.id) {
+      return 'Task move failed: Task ID not found'
+    }
+    return `Task moved successfully:\n• Task ID: ${ChorusFormatter.task(result.task.id)}\n• New column ID: ${result.task.columnId}\n• Position: ${result.task.position}`
   }
 
   private formatMoveTaskToProject(result: any): string {
-    const projectIdFormatted = result.task?.projectId
+    if (!result.task?.id) {
+      return 'Task move to project failed: Task ID not found'
+    }
+    const projectIdFormatted = result.task.projectId
       ? ChorusFormatter.project(result.task.projectId)
       : 'orphaned'
-    return `Task moved to project:\n• Task ID: ${ChorusFormatter.task(result.task?.id)}\n• New project ID: ${projectIdFormatted}\n• New column ID: ${result.task?.columnId}\n• Position: ${result.task?.position}`
+    return `Task moved to project:\n• Task ID: ${ChorusFormatter.task(result.task.id)}\n• New project ID: ${projectIdFormatted}\n• New column ID: ${result.task.columnId}\n• Position: ${result.task.position}`
   }
 
   private formatArchiveTask(result: any): string {
-    return `Task archived successfully:\n• Task ID: ${ChorusFormatter.task(result.task?.id)}`
+    if (!result.task?.id) {
+      return 'Task archive failed: Task ID not found'
+    }
+    return `Task archived successfully:\n• Task ID: ${ChorusFormatter.task(result.task.id)}`
   }
 
   private formatUnarchiveTask(result: any): string {
-    return `Task unarchived successfully:\n• Task ID: ${ChorusFormatter.task(result.task?.id)}`
+    if (!result.task?.id) {
+      return 'Task unarchive failed: Task ID not found'
+    }
+    return `Task unarchived successfully:\n• Task ID: ${ChorusFormatter.task(result.task.id)}`
   }
 
   private formatGetTaskById(result: any): string {

--- a/packages/server/src/services/agentic-loop/tool-formatters/task-formatter.ts
+++ b/packages/server/src/services/agentic-loop/tool-formatters/task-formatter.ts
@@ -70,13 +70,14 @@ export class TaskToolFormatter implements ToolResultFormatter {
   }
 
   private formatMoveTaskToProject(result: any): string {
-    return `Task moved to project:\n• Task ID: ${result.task?.id}\n• New project ID: ${
-      result.task?.projectId || 'orphaned'
-    }\n• New column ID: ${result.task?.columnId}\n• Position: ${result.task?.position}`
+    const projectIdFormatted = result.task?.projectId
+      ? ChorusFormatter.project(result.task.projectId)
+      : 'orphaned'
+    return `Task moved to project:\n• Task ID: ${ChorusFormatter.task(result.task?.id)}\n• New project ID: ${projectIdFormatted}\n• New column ID: ${result.task?.columnId}\n• Position: ${result.task?.position}`
   }
 
   private formatArchiveTask(result: any): string {
-    return `Task archived successfully:\n• Task ID: ${result.task?.id}`
+    return `Task archived successfully:\n• Task ID: ${ChorusFormatter.task(result.task?.id)}`
   }
 
   private formatUnarchiveTask(result: any): string {

--- a/packages/server/src/services/agentic-loop/tool-formatters/task-formatter.ts
+++ b/packages/server/src/services/agentic-loop/tool-formatters/task-formatter.ts
@@ -66,7 +66,7 @@ export class TaskToolFormatter implements ToolResultFormatter {
   }
 
   private formatMoveTask(result: any): string {
-    return `Task moved successfully:\n• Task ID: ${result.task?.id}\n• New column ID: ${result.task?.columnId}\n• Position: ${result.task?.position}`
+    return `Task moved successfully:\n• Task ID: ${ChorusFormatter.task(result.task?.id)}\n• New column ID: ${result.task?.columnId}\n• Position: ${result.task?.position}`
   }
 
   private formatMoveTaskToProject(result: any): string {
@@ -80,7 +80,7 @@ export class TaskToolFormatter implements ToolResultFormatter {
   }
 
   private formatUnarchiveTask(result: any): string {
-    return `Task unarchived successfully:\n• Task ID: ${result.task?.id}`
+    return `Task unarchived successfully:\n• Task ID: ${ChorusFormatter.task(result.task?.id)}`
   }
 
   private formatGetTaskById(result: any): string {
@@ -103,7 +103,8 @@ export class TaskToolFormatter implements ToolResultFormatter {
     const taskList =
       result.tasks
         ?.map(
-          (t: any) => `${t.title} (ID: ${t.id}) - Column: ${t.columnId}, Position: ${t.position}`
+          (t: any) =>
+            `${t.title} (ID: ${ChorusFormatter.task(t.id)}) - Column: ${t.columnId}, Position: ${t.position}`
         )
         .join('\n• ') || 'No tasks found in project'
     return `Project tasks:\n• ${taskList}`
@@ -112,7 +113,9 @@ export class TaskToolFormatter implements ToolResultFormatter {
   private formatGetOrphanedTasks(result: any): string {
     const taskList =
       result.tasks
-        ?.map((t: any) => `${t.title} (ID: ${t.id}) - Position: ${t.position}`)
+        ?.map(
+          (t: any) => `${t.title} (ID: ${ChorusFormatter.task(t.id)}) - Position: ${t.position}`
+        )
         .join('\n• ') || 'No orphaned tasks found'
     return `Orphaned tasks:\n• ${taskList}`
   }


### PR DESCRIPTION
## Summary
- Remove unused `displayText` parameters from ChorusFormatter methods
- Add missing ChorusFormatter calls in task and document formatters for consistency

## Context
These fixes address outstanding Cursor review feedback from the merged CHORUS_TAG navigation PR. The changes ensure consistent formatting across all tool formatters and remove unused parameters.

## Changes
- **ChorusFormatter**: Removed unused `displayText` parameters from all methods
- **TaskFormatter**: Added missing ChorusFormatter calls in `formatMoveTaskToProject` and `formatArchiveTask`
- **DocumentFormatter**: Added missing ChorusFormatter call in `formatSearchProjectDocuments`

🤖 Generated with [Claude Code](https://claude.ai/code)