### PR TITLE
fix: Handle missing content field in DocumentCreatedEvent component

### DIFF
--- a/packages/web/src/components/history/events/DocumentCreatedEvent.tsx
+++ b/packages/web/src/components/history/events/DocumentCreatedEvent.tsx
@@ -16,7 +16,7 @@ export const DocumentCreatedEvent: React.FC<DocumentCreatedEventProps> = ({ even
   const data = event.data as {
     id: string
     title: string
-    content: string
+    content?: string
   }
 
   const handleViewDocument = () => {
@@ -25,8 +25,11 @@ export const DocumentCreatedEvent: React.FC<DocumentCreatedEventProps> = ({ even
 
   const icon = <FileText size={16} className='text-amber-600' />
 
-  const previewContent =
-    data.content.length > 100 ? data.content.substring(0, 100) + '...' : data.content
+  const previewContent = data.content
+    ? data.content.length > 100
+      ? data.content.substring(0, 100) + '...'
+      : data.content
+    : undefined
 
   return (
     <BaseEventItem


### PR DESCRIPTION
## Summary
- Fixes TypeError when displaying document created events in the history panel
- Resolves issue where events with missing content field caused crashes
- Makes DocumentCreatedEvent component more resilient to incomplete data

## Background
The error `TypeError: Cannot read properties of undefined (reading 'length')` was occurring because:

1. The `DocumentCreatedEvent` component expected `data.content` to always exist
2. However, the `v1.DocumentCreated` event materializer only stores `{ id, title }` in the `eventData`
3. When the component tried to access `data.content.length`, `data.content` was undefined

## Changes
- Make content field optional in type definition (`content?: string`)
- Add null checks before accessing `content.length`
- Safely handle undefined content in preview generation
- Component now gracefully displays document title without content preview when content is unavailable

## Test plan
- [x] All existing unit tests pass
- [x] Lint and typecheck pass
- [x] Component handles missing content field without errors
- [x] BaseEventItem properly handles optional details prop

🤖 Generated with [Claude Code](https://claude.ai/code)