### PR TITLE
Improve LLM tool schema and formatter alignment

### DIFF
--- a/docs/llm-tools.md
+++ b/docs/llm-tools.md
@@ -10,6 +10,30 @@ Work Squared uses LiveStore's event-sourced architecture where:
 - **Queries** represent read operations
 - **LLM Tools** provide AI assistants access to these operations
 
+## Recent Changes (January 2025)
+
+### Breaking Changes
+
+- **Task Tools:**
+  - `create_task`: Now requires `projectId` and `columnId` (no defaults)
+  - `create_task`: Changed `assigneeId` → `assigneeIds` (array)
+  - Renamed `move_task` → `move_task_within_project`
+  - New `orphan_task` tool for orphaning tasks
+  - `move_task_to_project` now requires `toProjectId`
+
+### Improvements
+
+- **Formatters:**
+  - Added `ContactToolFormatter` for contact tool responses
+  - Standardized date formatting to ISO strings
+  - Enriched query results with human-readable names
+  - Added TypeScript interfaces for formatter contracts
+
+- **Schema Alignment:**
+  - Fixed terminology drift (board → project)
+  - Improved schema descriptions with side effects documented
+  - Aligned parameter requirements with actual behavior
+
 ## Architecture
 
 The LLM tools system has been fully refactored with a modular architecture:
@@ -44,8 +68,9 @@ src/utils/llm-tools/
 |                   | columnRenamed               | ❌   | -                            |
 |                   | columnReordered             | ❌   | -                            |
 | **Tasks**         | taskCreated                 | ✅   | create_task                  |
-|                   | taskMoved                   | ✅   | move_task                    |
+|                   | taskMoved                   | ✅   | move_task_within_project     |
 |                   | taskMovedToProject          | ✅   | move_task_to_project         |
+|                   | taskMovedToProject (orphan) | ✅   | orphan_task                  |
 |                   | taskUpdated                 | ✅   | update_task                  |
 |                   | taskArchived                | ✅   | archive_task                 |
 |                   | taskUnarchived              | ✅   | unarchive_task               |

--- a/docs/plans/019-llm-tool-schema-formatter-alignment.md
+++ b/docs/plans/019-llm-tool-schema-formatter-alignment.md
@@ -1,29 +1,35 @@
 # Plan 019: LLM Tool Schema & Formatter Alignment
 
 ## Goal
+
 Bring the LLM-facing tool schemas in `packages/server/src/tools/schemas.ts` back in sync with their actual behavior and formatter outputs so assistants receive precise affordances, use the right parameters, and interpret tool responses consistently.
 
 ## Key Findings
 
 ### Task tools (`packages/server/src/tools/schemas.ts`, `packages/server/src/tools/tasks.ts`, `packages/server/src/services/agentic-loop/tool-formatters/task-formatter.ts`)
+
 - `create_task` still uses legacy "board" terminology (`boardId`, `boardName`) even though the underlying API deals exclusively in projects; the formatter echoes the same mismatch. Allowing both `boardId` and `columnId` to be omitted forces accidental defaults to the first project/column, which is rarely desirable. Inputs mix singular (`assigneeId`) and plural (`assigneeIds`) conventions.
 - `move_task` only works for non-orphaned tasks (`moveTaskCore` throws on `!task.projectId`), but the schema description implies any column move is allowed. It also hides the implicit requirement that `toColumnId` belongs to the task's current project.
 - `move_task_to_project` accepts `toProjectId` as optional, relying on `getOrphanedColumns$` when absent. Neither the schema description nor formatter messaging explain when to omit `toProjectId` or how to select an orphan column.
 - Query tools (`get_project_tasks`, `get_orphaned_tasks`, `get_task_by_id`) return raw IDs without column metadata; the formatter repeats those IDs verbatim, so the LLM has no friendly names to work with.
 
 ### Project tools (`packages/server/src/tools/projects.ts`, `packages/server/src/services/agentic-loop/tool-formatters/project-formatter.ts`)
+
 - `create_project` silently provisions the default Kanban columns (`DEFAULT_KANBAN_COLUMNS`), but the schema description never mentions that side effect. The formatter highlights it, so schema/formatter messaging diverge.
 - `get_project_details` returns document and task counts, yet the description only promises "detailed information". Being explicit would help the LLM decide whether this tool satisfies reporting requests.
 
 ### Document tools (`packages/server/src/tools/documents.ts`, `packages/server/src/services/agentic-loop/tool-formatters/document-formatter.ts`)
+
 - `search_project_documents` marks `projectId` optional even though the description states "within a specific project". When omitted the implementation searches across all documents, potentially surprising the LLM.
 - Formatter outputs surface `new Date(...).toLocaleDateString()` results; there is no guarantee of locale consistency, which might impede deterministic parsing.
 
 ### Contact & worker tools
+
 - Contact tools lack a dedicated formatter, so most responses fall back to raw JSON dumps. That makes it harder for the assistant to read summaries, and the schema descriptions do not warn about large payloads (e.g., `validate_email_list`).
 - Worker formatter messages depend on fields (e.g., `result.worker.systemPrompt`) that are not documented anywhere, and some tool results (`deactivate_worker`) only expose a boolean `success`/`message`, which the schema descriptions should convey.
 
 ### Cross-cutting
+
 - Result payloads and formatter expectations are implicit. There is no shared contract describing what fields a tool must return for its formatter, making regressions easy.
 - Naming drift (`board` vs `project`, singular vs plural IDs) and optional parameters that trigger hidden defaults are the main sources of LLM confusion the team has observed.
 
@@ -55,7 +61,34 @@ Bring the LLM-facing tool schemas in `packages/server/src/tools/schemas.ts` back
    - Update `docs/llm-tools.md` and any MCP integration docs after schema updates so external consumers know about renamed inputs and stricter requirements.
    - Provide migration guidance (breaking changes, tooling updates) and implement tests plus `pnpm lint-all`/`pnpm test` to guard the refactor.
 
-## Open Questions
-- Do we need temporary backward-compatible aliases (`boardId`, `move_task`) for existing agent prompts, or can we cut over immediately once documentation is updated?
-- Should orphaned task handling become its own tool for clarity, or stay as `move_task_to_project` behavior?
-- Are there downstream systems relying on locale-specific dates from the document formatter that would break if we standardize to ISO strings?
+## Implementation Decisions
+
+### Resolved Questions
+
+- **Backward compatibility**: No aliases needed - clean cutover from `boardId` to `projectId`
+- **Orphaned task handling**: Create a separate `orphan_task` tool for clarity, making it explicit that most task tools require a project_id
+- **Date formatting**: Standardize to ISO strings immediately
+- **Formatter contracts**: Add interfaces directly to related formatter or tool files as appropriate
+- **Testing**: Add tests alongside implementation
+- **Migration**: No deprecation period - clean cutover
+
+### Implementation Order
+
+1. **Task tool terminology fixes** (highest impact)
+   - Rename `boardId` → `projectId` across schemas, implementations, and formatters
+   - Switch to consistent `assigneeIds` (plural)
+   - Rename `move_task` → `move_task_within_project`
+   - Create new `orphan_task` tool
+
+2. **Formatter contracts and shared types**
+   - Create TypeScript interfaces for formatter results
+   - Add compile-time validation
+
+3. **Formatter improvements**
+   - Add ContactToolFormatter
+   - Standardize date formatting to ISO strings
+   - Enrich query results with human-readable names
+
+4. **Testing and validation**
+   - Add tests for schema-formatter alignment
+   - Verify all formatter contracts are satisfied

--- a/docs/plans/019-llm-tool-schema-formatter-alignment.md
+++ b/docs/plans/019-llm-tool-schema-formatter-alignment.md
@@ -1,0 +1,61 @@
+# Plan 019: LLM Tool Schema & Formatter Alignment
+
+## Goal
+Bring the LLM-facing tool schemas in `packages/server/src/tools/schemas.ts` back in sync with their actual behavior and formatter outputs so assistants receive precise affordances, use the right parameters, and interpret tool responses consistently.
+
+## Key Findings
+
+### Task tools (`packages/server/src/tools/schemas.ts`, `packages/server/src/tools/tasks.ts`, `packages/server/src/services/agentic-loop/tool-formatters/task-formatter.ts`)
+- `create_task` still uses legacy "board" terminology (`boardId`, `boardName`) even though the underlying API deals exclusively in projects; the formatter echoes the same mismatch. Allowing both `boardId` and `columnId` to be omitted forces accidental defaults to the first project/column, which is rarely desirable. Inputs mix singular (`assigneeId`) and plural (`assigneeIds`) conventions.
+- `move_task` only works for non-orphaned tasks (`moveTaskCore` throws on `!task.projectId`), but the schema description implies any column move is allowed. It also hides the implicit requirement that `toColumnId` belongs to the task's current project.
+- `move_task_to_project` accepts `toProjectId` as optional, relying on `getOrphanedColumns$` when absent. Neither the schema description nor formatter messaging explain when to omit `toProjectId` or how to select an orphan column.
+- Query tools (`get_project_tasks`, `get_orphaned_tasks`, `get_task_by_id`) return raw IDs without column metadata; the formatter repeats those IDs verbatim, so the LLM has no friendly names to work with.
+
+### Project tools (`packages/server/src/tools/projects.ts`, `packages/server/src/services/agentic-loop/tool-formatters/project-formatter.ts`)
+- `create_project` silently provisions the default Kanban columns (`DEFAULT_KANBAN_COLUMNS`), but the schema description never mentions that side effect. The formatter highlights it, so schema/formatter messaging diverge.
+- `get_project_details` returns document and task counts, yet the description only promises "detailed information". Being explicit would help the LLM decide whether this tool satisfies reporting requests.
+
+### Document tools (`packages/server/src/tools/documents.ts`, `packages/server/src/services/agentic-loop/tool-formatters/document-formatter.ts`)
+- `search_project_documents` marks `projectId` optional even though the description states "within a specific project". When omitted the implementation searches across all documents, potentially surprising the LLM.
+- Formatter outputs surface `new Date(...).toLocaleDateString()` results; there is no guarantee of locale consistency, which might impede deterministic parsing.
+
+### Contact & worker tools
+- Contact tools lack a dedicated formatter, so most responses fall back to raw JSON dumps. That makes it harder for the assistant to read summaries, and the schema descriptions do not warn about large payloads (e.g., `validate_email_list`).
+- Worker formatter messages depend on fields (e.g., `result.worker.systemPrompt`) that are not documented anywhere, and some tool results (`deactivate_worker`) only expose a boolean `success`/`message`, which the schema descriptions should convey.
+
+### Cross-cutting
+- Result payloads and formatter expectations are implicit. There is no shared contract describing what fields a tool must return for its formatter, making regressions easy.
+- Naming drift (`board` vs `project`, singular vs plural IDs) and optional parameters that trigger hidden defaults are the main sources of LLM confusion the team has observed.
+
+## Recommended Changes
+
+1. **Standardize task terminology and inputs**
+   - Rename `boardId` → `projectId` across schemas, types, implementations, and formatters, keeping an alias only if absolutely necessary for backward compatibility.
+   - Require explicit `projectId` (and likely `columnId`) in `create_task`; document that the first-column fallback is temporary until deprecation.
+   - Switch `assigneeId` to `assigneeIds` for task creation so new tasks mirror the update API.
+   - Rename `move_task` → `move_task_within_project` (or similar) to encode its scope, and tighten the description to warn about orphaned tasks and column ownership.
+
+2. **Clarify cross-project moves and orphan handling**
+   - Update `move_task_to_project` schema text to spell out when to omit `toProjectId`, how to select orphan columns, and the validation performed (`getOrphanedColumns$`).
+   - Consider splitting orphaning into an explicit `orphan_task` helper if we want the LLM to avoid juggling column IDs for that edge case.
+
+3. **Align schema descriptions with runtime side effects**
+   - Expand `create_project` and `get_project_details` descriptions to match formatter messaging (default columns, counts returned).
+   - Fix `search_project_documents` to either require `projectId` or advertise the "all projects" fallback; document locale considerations for date formatting if we keep `toLocaleDateString()`.
+
+4. **Document and validate formatter contracts**
+   - Create shared TypeScript interfaces (e.g., `TaskFormatterResult`) used by both tool implementations and formatters so missing fields surface at compile time.
+   - Add assertions/tests that formatter-required fields are present in tool responses, especially for task creation/moves.
+
+5. **Improve formatter coverage and output fidelity**
+   - Add a `ContactToolFormatter` and extend task/document formatters to surface human-readable column/project names by enriching query results.
+   - Normalize date formatting (e.g., ISO strings) before formatting so downstream parsing is deterministic.
+
+6. **Documentation & migration**
+   - Update `docs/llm-tools.md` and any MCP integration docs after schema updates so external consumers know about renamed inputs and stricter requirements.
+   - Provide migration guidance (breaking changes, tooling updates) and implement tests plus `pnpm lint-all`/`pnpm test` to guard the refactor.
+
+## Open Questions
+- Do we need temporary backward-compatible aliases (`boardId`, `move_task`) for existing agent prompts, or can we cut over immediately once documentation is updated?
+- Should orphaned task handling become its own tool for clarity, or stay as `move_task_to_project` behavior?
+- Are there downstream systems relying on locale-specific dates from the document formatter that would break if we standardize to ISO strings?

--- a/packages/server/src/services/agentic-loop/braintrust-provider.ts
+++ b/packages/server/src/services/agentic-loop/braintrust-provider.ts
@@ -79,7 +79,7 @@ WORKER PROFILE:
 ${sanitizedWorkerContext.roleDescription ? `- Role: ${sanitizedWorkerContext.roleDescription}` : ''}
 
 You have access to tools for:
-- Creating and managing tasks (create_task, update_task, move_task, move_task_to_project, archive_task, unarchive_task)
+- Creating and managing tasks (create_task, update_task, move_task_within_project, move_task_to_project, orphan_task, archive_task, unarchive_task)
 - Viewing tasks (get_task_by_id, get_project_tasks, get_orphaned_tasks)
 - Managing projects (list_projects, get_project_details)
 - Creating and managing documents (create_document, update_document, archive_document)
@@ -113,7 +113,7 @@ Remember: You're not just answering questions—you're helping build successful 
       systemPrompt = `${baseSystemPrompt}
 
 You have access to tools for:
-- Creating and managing tasks (create_task, update_task, move_task, move_task_to_project, archive_task, unarchive_task)
+- Creating and managing tasks (create_task, update_task, move_task_within_project, move_task_to_project, orphan_task, archive_task, unarchive_task)
 - Viewing tasks (get_task_by_id, get_project_tasks, get_orphaned_tasks)
 - Managing projects (list_projects, get_project_details)
 - Creating and managing documents (create_document, update_document, archive_document)

--- a/packages/server/src/services/agentic-loop/tool-formatters/chorus-formatter.ts
+++ b/packages/server/src/services/agentic-loop/tool-formatters/chorus-formatter.ts
@@ -4,7 +4,7 @@
  */
 
 export interface ChorusTag {
-  type: 'document' | 'project' | 'task' | 'file'
+  type: 'document' | 'project' | 'task' | 'file' | 'contact'
   id?: string
   path?: string
 }
@@ -36,6 +36,13 @@ export class ChorusFormatter {
   }
 
   /**
+   * Wraps a contact ID in a CHORUS_TAG for navigation to contact details
+   */
+  static contact(contactId: string, options?: ChorusFormatterOptions): string {
+    return this.wrap('contact', contactId, options)
+  }
+
+  /**
    * Wraps a file path in a CHORUS_TAG for file system navigation
    */
   static file(filePath: string, options?: ChorusFormatterOptions): string {
@@ -46,7 +53,11 @@ export class ChorusFormatter {
    * Creates a formatted reference with both readable text and clickable ID
    * Example: "Document: My Document (ID: <CHORUS_TAG path=\"document:123\">123</CHORUS_TAG>)"
    */
-  static reference(type: 'document' | 'project' | 'task', id: string, title?: string): string {
+  static reference(
+    type: 'document' | 'project' | 'task' | 'contact',
+    id: string,
+    title?: string
+  ): string {
     const chorusTag = this[type](id)
     if (title) {
       return `${title} (ID: ${chorusTag})`

--- a/packages/server/src/services/agentic-loop/tool-formatters/contact-formatter.ts
+++ b/packages/server/src/services/agentic-loop/tool-formatters/contact-formatter.ts
@@ -1,0 +1,213 @@
+import type { ToolResultFormatter } from './types.js'
+import { ChorusFormatter } from './chorus-formatter.js'
+
+export class ContactToolFormatter implements ToolResultFormatter {
+  private readonly contactTools = [
+    'list_contacts',
+    'get_contact',
+    'search_contacts',
+    'create_contact',
+    'update_contact',
+    'delete_contact',
+    'get_project_contacts',
+    'get_contact_projects',
+    'add_contact_to_project',
+    'remove_contact_from_project',
+    'get_project_email_list',
+    'find_contacts_by_email',
+    'get_project_contact_emails',
+    'validate_email_list',
+    'suggest_contacts_from_emails',
+  ]
+
+  canFormat(toolName: string): boolean {
+    return this.contactTools.includes(toolName)
+  }
+
+  format(toolResult: any, toolCall: any): string {
+    const toolName = toolCall.function.name
+
+    switch (toolName) {
+      case 'list_contacts':
+        return this.formatListContacts(toolResult)
+      case 'get_contact':
+        return this.formatGetContact(toolResult)
+      case 'search_contacts':
+        return this.formatSearchContacts(toolResult)
+      case 'create_contact':
+        return this.formatCreateContact(toolResult)
+      case 'update_contact':
+        return this.formatUpdateContact(toolResult)
+      case 'delete_contact':
+        return this.formatDeleteContact(toolResult)
+      case 'get_project_contacts':
+        return this.formatGetProjectContacts(toolResult)
+      case 'get_contact_projects':
+        return this.formatGetContactProjects(toolResult)
+      case 'add_contact_to_project':
+        return this.formatAddContactToProject(toolResult)
+      case 'remove_contact_from_project':
+        return this.formatRemoveContactFromProject(toolResult)
+      case 'get_project_email_list':
+        return this.formatGetProjectEmailList(toolResult)
+      case 'find_contacts_by_email':
+        return this.formatFindContactsByEmail(toolResult)
+      case 'get_project_contact_emails':
+        return this.formatGetProjectContactEmails(toolResult)
+      case 'validate_email_list':
+        return this.formatValidateEmailList(toolResult)
+      case 'suggest_contacts_from_emails':
+        return this.formatSuggestContactsFromEmails(toolResult)
+      default:
+        return `Contact operation completed: ${JSON.stringify(toolResult, null, 2)}`
+    }
+  }
+
+  private formatListContacts(result: any): string {
+    if (!result.contacts?.length) {
+      return 'No contacts found'
+    }
+    const contactList = result.contacts
+      .map((c: any) => `${c.name} (${c.email}) - ID: ${ChorusFormatter.contact(c.id)}`)
+      .join('\n• ')
+    return `Contacts:\n• ${contactList}`
+  }
+
+  private formatGetContact(result: any): string {
+    if (!result.contact) {
+      return 'Contact not found'
+    }
+    const c = result.contact
+    let message = `Contact details:\n• ID: ${ChorusFormatter.contact(c.id)}\n• Name: ${c.name}\n• Email: ${c.email}`
+    if (c.company) message += `\n• Company: ${c.company}`
+    if (c.role) message += `\n• Role: ${c.role}`
+    if (c.phone) message += `\n• Phone: ${c.phone}`
+    if (c.notes) message += `\n• Notes: ${c.notes}`
+    return message
+  }
+
+  private formatSearchContacts(result: any): string {
+    if (!result.results?.length) {
+      return 'No matching contacts found'
+    }
+    const searchResults = result.results
+      .map((c: any) => `${c.name} (${c.email}) - ID: ${ChorusFormatter.contact(c.id)}`)
+      .join('\n• ')
+    return `Search results:\n• ${searchResults}`
+  }
+
+  private formatCreateContact(result: any): string {
+    if (result?.success === false) {
+      return `Contact creation failed: ${result?.error ?? 'Unknown error'}`
+    }
+    return `Contact created successfully:\n• ID: ${ChorusFormatter.contact(result.contact.id)}\n• Name: ${result.contact.name}\n• Email: ${result.contact.email}`
+  }
+
+  private formatUpdateContact(result: any): string {
+    if (result?.success === false) {
+      return `Contact update failed: ${result?.error ?? 'Unknown error'}`
+    }
+    return `Contact updated successfully:\n• ID: ${ChorusFormatter.contact(result.contact.id)}\n• Name: ${result.contact.name}`
+  }
+
+  private formatDeleteContact(result: any): string {
+    if (result?.success === false) {
+      return `Contact deletion failed: ${result?.error ?? 'Unknown error'}`
+    }
+    return `Contact deleted successfully: ${result.contactId}`
+  }
+
+  private formatGetProjectContacts(result: any): string {
+    if (!result.contacts?.length) {
+      return 'No contacts found for this project'
+    }
+    const contactList = result.contacts
+      .map((c: any) => `${c.name} (${c.email}) - ID: ${ChorusFormatter.contact(c.id)}`)
+      .join('\n• ')
+    return `Project contacts:\n• ${contactList}`
+  }
+
+  private formatGetContactProjects(result: any): string {
+    if (!result.projects?.length) {
+      return 'Contact is not associated with any projects'
+    }
+    const projectList = result.projects
+      .map((p: any) => `${p.name} - ID: ${ChorusFormatter.project(p.id)}`)
+      .join('\n• ')
+    return `Contact's projects:\n• ${projectList}`
+  }
+
+  private formatAddContactToProject(result: any): string {
+    if (result?.success === false) {
+      return `Failed to add contact to project: ${result?.error ?? 'Unknown error'}`
+    }
+    return `Contact successfully added to project`
+  }
+
+  private formatRemoveContactFromProject(result: any): string {
+    if (result?.success === false) {
+      return `Failed to remove contact from project: ${result?.error ?? 'Unknown error'}`
+    }
+    return `Contact successfully removed from project`
+  }
+
+  private formatGetProjectEmailList(result: any): string {
+    if (!result.emails?.length) {
+      return 'No email addresses found for this project'
+    }
+    const emailList = result.emails.map((email: string) => `• ${email}`).join('\n')
+    return `Project email list:\n${emailList}`
+  }
+
+  private formatFindContactsByEmail(result: any): string {
+    if (!result.contacts?.length) {
+      return 'No contacts found with the specified email addresses'
+    }
+    const contactList = result.contacts
+      .map((c: any) => `${c.name} (${c.email}) - ID: ${ChorusFormatter.contact(c.id)}`)
+      .join('\n• ')
+    return `Found contacts:\n• ${contactList}`
+  }
+
+  private formatGetProjectContactEmails(result: any): string {
+    if (!result.emails?.length) {
+      return 'No contact emails found for this project'
+    }
+    return `Project contact emails:\n• ${result.emails.join('\n• ')}`
+  }
+
+  private formatValidateEmailList(result: any): string {
+    let message = 'Email validation results:\n'
+
+    if (result.valid?.length) {
+      message += `\nValid emails (${result.valid.length}):\n• ${result.valid.join('\n• ')}`
+    }
+
+    if (result.invalid?.length) {
+      message += `\n\nInvalid emails (${result.invalid.length}):\n• ${result.invalid.join('\n• ')}`
+    }
+
+    if (result.duplicates?.length) {
+      message += `\n\nDuplicate emails (${result.duplicates.length}):\n• ${result.duplicates.join('\n• ')}`
+    }
+
+    return message
+  }
+
+  private formatSuggestContactsFromEmails(result: any): string {
+    if (!result.suggestions?.length) {
+      return 'No contact suggestions generated'
+    }
+
+    const suggestionList = result.suggestions
+      .map((s: any) => {
+        let item = `Email: ${s.email}`
+        if (s.suggestedName) item += ` → Suggested name: ${s.suggestedName}`
+        if (s.suggestedCompany) item += ` (${s.suggestedCompany})`
+        return item
+      })
+      .join('\n• ')
+
+    return `Contact suggestions:\n• ${suggestionList}`
+  }
+}

--- a/packages/server/src/services/agentic-loop/tool-formatters/document-formatter.ts
+++ b/packages/server/src/services/agentic-loop/tool-formatters/document-formatter.ts
@@ -53,7 +53,7 @@ export class DocumentToolFormatter implements ToolResultFormatter {
       result.documents
         ?.map(
           (d: any) =>
-            `${d.title} (ID: ${ChorusFormatter.document(d.id)}) - Updated: ${new Date(d.updatedAt).toLocaleDateString()}`
+            `${d.title} (ID: ${ChorusFormatter.document(d.id)}) - Updated: ${new Date(d.updatedAt).toISOString()}`
         )
         .join('\n• ') || 'No documents found'
     return `Available documents:\n• ${documentList}`
@@ -82,7 +82,7 @@ export class DocumentToolFormatter implements ToolResultFormatter {
       result.documents
         ?.map(
           (d: any) =>
-            `${d.title} (ID: ${ChorusFormatter.document(d.id)}) - Created: ${new Date(d.createdAt).toLocaleDateString()}`
+            `${d.title} (ID: ${ChorusFormatter.document(d.id)}) - Created: ${new Date(d.createdAt).toISOString()}`
         )
         .join('\n• ') || 'No documents found in project'
     return `Project documents:\n• ${documentList}`

--- a/packages/server/src/services/agentic-loop/tool-formatters/formatter-service.ts
+++ b/packages/server/src/services/agentic-loop/tool-formatters/formatter-service.ts
@@ -3,6 +3,7 @@ import { TaskToolFormatter } from './task-formatter.js'
 import { DocumentToolFormatter } from './document-formatter.js'
 import { ProjectToolFormatter } from './project-formatter.js'
 import { WorkerToolFormatter } from './worker-formatter.js'
+import { ContactToolFormatter } from './contact-formatter.js'
 
 export class ToolResultFormatterService {
   private formatters: ToolResultFormatter[] = [
@@ -10,6 +11,7 @@ export class ToolResultFormatterService {
     new DocumentToolFormatter(),
     new ProjectToolFormatter(),
     new WorkerToolFormatter(),
+    new ContactToolFormatter(),
   ]
 
   format(toolResult: any, toolCall: any): string {

--- a/packages/server/src/services/agentic-loop/tool-formatters/task-formatter.test.ts
+++ b/packages/server/src/services/agentic-loop/tool-formatters/task-formatter.test.ts
@@ -5,24 +5,24 @@ import { TaskToolFormatter } from './task-formatter.js'
 const createTaskToolCall = { function: { name: 'create_task' } }
 
 describe('TaskToolFormatter', () => {
-  it('includes the provided board name in create_task output', () => {
+  it('includes the provided project name in create_task output', () => {
     const formatter = new TaskToolFormatter()
     const resultMessage = formatter.format(
       {
         success: true,
         taskTitle: 'Spin up test environment',
-        boardName: "Danvers' Game of LifeSquared",
+        projectName: "Danvers' Game of LifeSquared",
         columnName: 'To Do',
         taskId: 'task-123',
       },
       createTaskToolCall
     )
 
-    expect(resultMessage).toContain(`on board "Danvers' Game of LifeSquared"`)
+    expect(resultMessage).toContain(`in project "Danvers' Game of LifeSquared"`)
     expect(resultMessage).toContain('<CHORUS_TAG path="task:task-123">task-123</CHORUS_TAG>')
   })
 
-  it('falls back to project name when board name is not provided', () => {
+  it('uses project name when provided', () => {
     const formatter = new TaskToolFormatter()
     const resultMessage = formatter.format(
       {
@@ -35,7 +35,7 @@ describe('TaskToolFormatter', () => {
       createTaskToolCall
     )
 
-    expect(resultMessage).toContain('on board "LifeSquared Launch"')
+    expect(resultMessage).toContain('in project "LifeSquared Launch"')
   })
 
   it('surfaces task creation errors directly', () => {

--- a/packages/server/src/services/agentic-loop/tool-formatters/worker-formatter.ts
+++ b/packages/server/src/services/agentic-loop/tool-formatters/worker-formatter.ts
@@ -115,10 +115,8 @@ export class WorkerToolFormatter implements ToolResultFormatter {
       `**Default Model:** ${worker.defaultModel}`,
       worker.roleDescription ? `**Role:** ${worker.roleDescription}` : '',
       worker.avatar ? `**Avatar:** ${worker.avatar}` : '',
-      `**Created:** ${new Date(worker.createdAt).toLocaleDateString()}`,
-      worker.updatedAt
-        ? `**Last Updated:** ${new Date(worker.updatedAt).toLocaleDateString()}`
-        : '',
+      `**Created:** ${new Date(worker.createdAt).toISOString()}`,
+      worker.updatedAt ? `**Last Updated:** ${new Date(worker.updatedAt).toISOString()}` : '',
       '',
       `**System Prompt:**\n\`\`\`\n${worker.systemPrompt}\n\`\`\``,
       '',

--- a/packages/server/src/tools/index.ts
+++ b/packages/server/src/tools/index.ts
@@ -30,8 +30,9 @@ export async function executeLLMTool(
   const {
     createTask,
     updateTask,
-    moveTask,
+    moveTaskWithinProject,
     moveTaskToProject,
+    orphanTask,
     archiveTask,
     unarchiveTask,
     getTaskById,
@@ -91,11 +92,14 @@ export async function executeLLMTool(
     case 'update_task':
       return updateTask(store, toolCall.parameters)
 
-    case 'move_task':
-      return moveTask(store, toolCall.parameters)
+    case 'move_task_within_project':
+      return moveTaskWithinProject(store, toolCall.parameters)
 
     case 'move_task_to_project':
       return moveTaskToProject(store, toolCall.parameters)
+
+    case 'orphan_task':
+      return orphanTask(store, toolCall.parameters)
 
     case 'archive_task':
       return archiveTask(store, toolCall.parameters.taskId)

--- a/packages/server/src/tools/schema-formatter-alignment.test.ts
+++ b/packages/server/src/tools/schema-formatter-alignment.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest'
+import { TaskToolFormatter } from '../services/agentic-loop/tool-formatters/task-formatter.js'
+import { DocumentToolFormatter } from '../services/agentic-loop/tool-formatters/document-formatter.js'
+import { ContactToolFormatter } from '../services/agentic-loop/tool-formatters/contact-formatter.js'
+
+describe('Schema-Formatter Alignment', () => {
+  describe('Task Formatters', () => {
+    it('create_task formatter uses projectName not boardName', () => {
+      const formatter = new TaskToolFormatter()
+
+      // Test with new parameter names
+      const result = {
+        success: true,
+        taskId: 'task-123',
+        taskTitle: 'Test Task',
+        projectName: 'Test Project',
+        columnName: 'To Do',
+        assigneeNames: ['John', 'Jane'],
+      }
+
+      const formatted = formatter.format(result, {
+        function: { name: 'create_task' },
+      })
+
+      expect(formatted).toContain('Test Project')
+      expect(formatted).toContain('To Do')
+      expect(formatted).toContain('John, Jane')
+      expect(formatted).not.toContain('board')
+    })
+
+    it('move_task_within_project formatter describes within-project move', () => {
+      const formatter = new TaskToolFormatter()
+
+      const result = {
+        success: true,
+        task: {
+          id: 'task-123',
+          columnId: 'column-2',
+          position: 0,
+        },
+      }
+
+      const formatted = formatter.format(result, {
+        function: { name: 'move_task_within_project' },
+      })
+
+      expect(formatted).toContain('within project')
+      expect(formatted).toContain('task-123')
+      expect(formatted).toContain('column-2')
+    })
+
+    it('orphan_task formatter describes orphaning', () => {
+      const formatter = new TaskToolFormatter()
+
+      const result = {
+        success: true,
+        task: {
+          id: 'task-123',
+          columnId: 'orphan-column',
+          position: 0,
+        },
+      }
+
+      const formatted = formatter.format(result, {
+        function: { name: 'orphan_task' },
+      })
+
+      expect(formatted).toContain('orphaned')
+      expect(formatted).toContain('task-123')
+      expect(formatted).toContain('orphan-column')
+    })
+
+    it('get_project_tasks includes project name and column names', () => {
+      const formatter = new TaskToolFormatter()
+
+      const result = {
+        success: true,
+        projectName: 'Test Project',
+        tasks: [
+          {
+            id: 'task-1',
+            title: 'Task 1',
+            columnId: 'col-1',
+            columnName: 'To Do',
+            position: 0,
+          },
+          {
+            id: 'task-2',
+            title: 'Task 2',
+            columnId: 'col-2',
+            columnName: 'In Progress',
+            position: 1,
+          },
+        ],
+      }
+
+      const formatted = formatter.format(result, {
+        function: { name: 'get_project_tasks' },
+      })
+
+      expect(formatted).toContain('Test Project')
+      expect(formatted).toContain('To Do')
+      expect(formatted).toContain('In Progress')
+      expect(formatted).not.toContain('col-1')
+      expect(formatted).not.toContain('col-2')
+    })
+  })
+
+  describe('Date Formatting', () => {
+    it('document formatter should use ISO strings for dates', () => {
+      const formatter = new DocumentToolFormatter()
+
+      const result = {
+        success: true,
+        documents: [
+          {
+            id: 'doc-1',
+            title: 'Document 1',
+            updatedAt: new Date('2024-01-15T10:30:00Z'),
+          },
+        ],
+      }
+
+      const formatted = formatter.format(result, {
+        function: { name: 'list_documents' },
+      })
+
+      expect(formatted).toContain('2024-01-15T10:30:00.000Z')
+      expect(formatted).not.toMatch(/\d{1,2}\/\d{1,2}\/\d{4}/) // No locale-specific dates
+    })
+  })
+
+  describe('Contact Formatter', () => {
+    it('formats contact list with proper CHORUS_TAG', () => {
+      const formatter = new ContactToolFormatter()
+
+      const result = {
+        success: true,
+        contacts: [
+          {
+            id: 'contact-1',
+            name: 'John Doe',
+            email: 'john@example.com',
+          },
+        ],
+      }
+
+      const formatted = formatter.format(result, {
+        function: { name: 'list_contacts' },
+      })
+
+      expect(formatted).toContain('John Doe')
+      expect(formatted).toContain('john@example.com')
+      expect(formatted).toContain('<CHORUS_TAG path="contact:contact-1">')
+    })
+
+    it('formats validation results clearly', () => {
+      const formatter = new ContactToolFormatter()
+
+      const result = {
+        success: true,
+        valid: ['valid@example.com'],
+        invalid: ['not-an-email'],
+        duplicates: ['dup@example.com'],
+      }
+
+      const formatted = formatter.format(result, {
+        function: { name: 'validate_email_list' },
+      })
+
+      expect(formatted).toContain('Valid emails (1)')
+      expect(formatted).toContain('valid@example.com')
+      expect(formatted).toContain('Invalid emails (1)')
+      expect(formatted).toContain('not-an-email')
+      expect(formatted).toContain('Duplicate emails (1)')
+      expect(formatted).toContain('dup@example.com')
+    })
+  })
+})

--- a/packages/server/src/tools/types.ts
+++ b/packages/server/src/tools/types.ts
@@ -8,9 +8,9 @@
 export interface CreateTaskParams {
   title: string
   description?: string
-  boardId?: string
-  columnId?: string
-  assigneeId?: string
+  projectId: string
+  columnId: string
+  assigneeIds?: string[]
 }
 
 export interface CreateTaskResult {
@@ -18,10 +18,9 @@ export interface CreateTaskResult {
   taskId?: string
   error?: string
   taskTitle?: string
-  boardName?: string
   projectName?: string
   columnName?: string
-  assigneeName?: string
+  assigneeNames?: string[]
 }
 
 export interface UpdateTaskParams {
@@ -60,7 +59,7 @@ export interface MoveTaskResult {
 
 export interface MoveTaskToProjectParams {
   taskId: string
-  toProjectId?: string
+  toProjectId: string
   toColumnId: string
   position?: number
 }
@@ -70,7 +69,23 @@ export interface MoveTaskToProjectResult {
   error?: string
   task?: {
     id: string
-    projectId?: string
+    projectId: string
+    columnId: string
+    position: number
+  }
+}
+
+export interface OrphanTaskParams {
+  taskId: string
+  toColumnId: string
+  position?: number
+}
+
+export interface OrphanTaskResult {
+  success: boolean
+  error?: string
+  task?: {
+    id: string
     columnId: string
     position: number
   }
@@ -128,10 +143,12 @@ export interface GetProjectTasksParams {
 
 export interface GetProjectTasksResult {
   success: boolean
+  projectName?: string
   tasks?: Array<{
     id: string
     projectId: string
     columnId: string
+    columnName?: string
     title: string
     description?: string
     assigneeIds?: string[]


### PR DESCRIPTION
## Summary
- add docs/plans/019-llm-tool-schema-formatter-alignment.md with detailed findings and recommendations
- highlight schema vs formatter mismatches for task, project, document, contact, and worker tools
- propose next steps for renaming, parameter tightening, formatter coverage, and documentation updates

## Testing
- not run (docs only)

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/13b4edb1-6fb2-41bf-a2ec-d2be5276e7a8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns LLM tool schemas with implementations/formatters, introduces breaking task tool changes, adds contact formatter, standardizes dates to ISO, enriches outputs, and updates tool routing/prompts.
> 
> - **Breaking changes (Tasks)**
>   - `create_task`: requires `projectId` and `columnId`; `assigneeIds` (array) replaces `assigneeId`.
>   - Rename `move_task` → `move_task_within_project`; add `orphan_task`.
>   - `move_task_to_project`: now requires `toProjectId` and validates target column.
> - **Schemas and core tools**
>   - Updated `packages/server/src/tools/schemas.ts` to reflect new params/descriptions (incl. clearer project/doc behaviors).
>   - Task implementations updated in `tasks.ts` (strict project/column validation, plural assignees, new orphaning flow, enriched `get_project_tasks` with `projectName`/`columnName`).
>   - `index.ts` routes updated to new task tool names; added `orphan_task`.
> - **Formatters**
>   - Added `ContactToolFormatter` and CHORUS `contact` tag; registered in `formatter-service`.
>   - Task formatter aligned with new fields/names; updated tests; adds within-project/orphan messages; shows human-readable column names.
>   - Document/Worker formatters switch date output to ISO strings.
> - **LLM provider prompt**
>   - Updated tool lists in `braintrust-provider.ts` to new task tool names, including `orphan_task`.
> - **Tests & docs**
>   - New `schema-formatter-alignment.test.ts`; refreshed task formatter tests.
>   - Docs: `docs/llm-tools.md` status table and “Recent Changes” section; added detailed plan in `docs/plans/019-llm-tool-schema-formatter-alignment.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14122507e739d9d1bdfef76d3ca578761ed7ed3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->