### PR TITLE
Fix TaskModal to use authenticated user for comment composer

### DIFF
--- a/packages/web/src/components/tasks/TaskModal/TaskModal.comment.test.tsx
+++ b/packages/web/src/components/tasks/TaskModal/TaskModal.comment.test.tsx
@@ -166,9 +166,8 @@ describe('TaskModal Comments', () => {
 
     renderWithProviders(<TaskModal taskId='task-1' onClose={() => {}} />)
 
-    const composerContainer = screen
-      .getByPlaceholderText('Add a comment...')
-      .parentElement?.parentElement?.parentElement as HTMLElement
+    const composerContainer = screen.getByPlaceholderText('Add a comment...').parentElement
+      ?.parentElement?.parentElement as HTMLElement
 
     expect(within(composerContainer).getByTitle('Bob Smith')).toBeInTheDocument()
   })
@@ -178,9 +177,8 @@ describe('TaskModal Comments', () => {
 
     renderWithProviders(<TaskModal taskId='task-1' onClose={() => {}} />)
 
-    const composerContainer = screen
-      .getByPlaceholderText('Add a comment...')
-      .parentElement?.parentElement?.parentElement as HTMLElement
+    const composerContainer = screen.getByPlaceholderText('Add a comment...').parentElement
+      ?.parentElement?.parentElement as HTMLElement
 
     expect(within(composerContainer).getByTitle('Alice Johnson')).toBeInTheDocument()
   })

--- a/packages/web/src/components/tasks/TaskModal/TaskModal.comment.test.tsx
+++ b/packages/web/src/components/tasks/TaskModal/TaskModal.comment.test.tsx
@@ -1,17 +1,24 @@
 import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { TaskModal } from './TaskModal.js'
 import { SnackbarProvider } from '../../ui/Snackbar/Snackbar.js'
 import type { Task, User, Comment } from '@work-squared/shared/schema'
 
 // Mock LiveStore hooks
+const { mockUseAuth } = vi.hoisted(() => ({
+  mockUseAuth: vi.fn(),
+}))
 const mockCommit = vi.fn()
 const mockStore = { commit: mockCommit }
 
 vi.mock('@livestore/react', () => ({
   useQuery: vi.fn(),
   useStore: vi.fn(() => ({ store: mockStore })),
+}))
+
+vi.mock('../../../contexts/AuthContext.js', () => ({
+  useAuth: () => mockUseAuth(),
 }))
 
 // Import after mocking
@@ -94,6 +101,13 @@ describe('TaskModal Comments', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: 'user-1',
+        email: 'alice@example.com',
+        instances: [],
+      },
+    })
 
     // Default mock implementation
     mockUseQuery.mockImplementation((query: any) => {
@@ -139,6 +153,36 @@ describe('TaskModal Comments', () => {
 
     expect(screen.getByPlaceholderText('Add a comment...')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Comment' })).toBeInTheDocument()
+  })
+
+  it('should use authenticated user for comment composer when available', () => {
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: 'user-2',
+        email: 'bob@example.com',
+        instances: [],
+      },
+    })
+
+    renderWithProviders(<TaskModal taskId='task-1' onClose={() => {}} />)
+
+    const composerContainer = screen
+      .getByPlaceholderText('Add a comment...')
+      .parentElement?.parentElement?.parentElement as HTMLElement
+
+    expect(within(composerContainer).getByTitle('Bob Smith')).toBeInTheDocument()
+  })
+
+  it('should fall back to first available user when auth user is missing', () => {
+    mockUseAuth.mockReturnValue({ user: null })
+
+    renderWithProviders(<TaskModal taskId='task-1' onClose={() => {}} />)
+
+    const composerContainer = screen
+      .getByPlaceholderText('Add a comment...')
+      .parentElement?.parentElement?.parentElement as HTMLElement
+
+    expect(within(composerContainer).getByTitle('Alice Johnson')).toBeInTheDocument()
   })
 
   it('should validate comment content', async () => {

--- a/packages/web/src/components/tasks/TaskModal/TaskModal.test.tsx
+++ b/packages/web/src/components/tasks/TaskModal/TaskModal.test.tsx
@@ -151,9 +151,8 @@ describe('TaskModal', () => {
 
     renderWithProviders(<TaskModal taskId='test-task' onClose={mockOnClose} />)
 
-    const composerContainer = screen
-      .getByPlaceholderText('Add a comment...')
-      .parentElement?.parentElement?.parentElement as HTMLElement
+    const composerContainer = screen.getByPlaceholderText('Add a comment...').parentElement
+      ?.parentElement?.parentElement as HTMLElement
 
     expect(within(composerContainer).getByTitle('Bob Smith')).toBeInTheDocument()
   })

--- a/packages/web/tests/test-utils.tsx
+++ b/packages/web/tests/test-utils.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom'
-import React, { type ReactElement, type ReactNode } from 'react'
+import React, { type ReactElement } from 'react'
 import { render, type RenderOptions } from '@testing-library/react'
 import type { Task, Column, Project, Contact } from '@work-squared/shared/schema'
 

--- a/packages/web/tests/unit/workers.test.ts
+++ b/packages/web/tests/unit/workers.test.ts
@@ -4,13 +4,22 @@ import { generateRandomWorkerName } from '../../src/util/workerNames.js'
 import { workerCreated, workerUpdated } from '@work-squared/shared/events'
 
 describe('Worker Name Generation', () => {
-  it('should generate different names on subsequent calls', () => {
-    const name1 = generateRandomWorkerName()
-    const name2 = generateRandomWorkerName()
+  it('should generate names in the correct format', () => {
+    // Generate multiple names to test format
+    for (let i = 0; i < 10; i++) {
+      const name = generateRandomWorkerName()
+      expect(name).toMatch(/^[A-Z][a-z]+ [A-Z][a-z]+$/)
+    }
+  })
 
-    expect(name1).toMatch(/^[A-Za-z]+ [A-Za-z]+$/)
-    expect(name2).toMatch(/^[A-Za-z]+ [A-Za-z]+$/)
-    expect(name1).not.toBe(name2) // Very unlikely to be the same
+  it('should generate names with reasonable variety', () => {
+    // Generate many names and check we get more than 1 unique name
+    const names = new Set()
+    for (let i = 0; i < 50; i++) {
+      names.add(generateRandomWorkerName())
+    }
+    // With 420 possible combinations, getting at least 10 unique names in 50 tries is very likely
+    expect(names.size).toBeGreaterThan(10)
   })
 })
 


### PR DESCRIPTION
## Summary
- Updated TaskModal to prefer the authenticated user for the comment composer.
- Falls back to the first available user if no authenticated user is found.
- Added tests to verify the comment composer uses the correct user based on authentication state.

## Changes

### Core Functionality
- Imported and used `useAuth` from AuthContext to get the authenticated user.
- Modified logic to select the current user for comments: tries to match authenticated user with users list, otherwise uses the first user.

### Tests
- Enhanced TaskModal and TaskModal.comment tests to mock authentication context.
- Added tests to confirm the comment composer shows the authenticated user when available.
- Added fallback test to confirm the first user is used when no authenticated user is present.

## Test plan
- [x] Run existing and new tests to ensure comment composer uses authenticated user.
- [x] Verify fallback to first user when authentication is missing.
- [x] Confirm UI displays correct user name in comment composer based on auth state.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/faf6252f-a1e0-4c8d-8041-c0c10b45d344

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> TaskModal now uses the authenticated user for the comment composer (falling back to the first user), with updated tests and refined worker name tests.
> 
> - **Frontend**
>   - **TaskModal** (`packages/web/src/components/tasks/TaskModal/TaskModal.tsx`):
>     - Import `useAuth` and select `currentUser` via authenticated user match; fallback to first `users` entry. Uses `useMemo` to derive `currentUser`.
> - **Tests**
>   - **TaskModal** (`TaskModal.test.tsx`, `TaskModal.comment.test.tsx`):
>     - Mock `AuthContext.useAuth` and verify composer shows authenticated user; add fallback test when auth user is missing. Use `within` for scoped queries and return `getUsers` data.
>   - **Workers** (`packages/web/tests/unit/workers.test.ts`):
>     - Update name generation tests to assert proper name format and ensure variety across generated names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf5fe0810201458a390f8fb9cd2a7f49919c1a05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->